### PR TITLE
refactor: 쿠폰 사용 현황 api 수정

### DIFF
--- a/src/main/java/mujinjang/couponsystem/domain/coupon/controller/CouponWalletController.java
+++ b/src/main/java/mujinjang/couponsystem/domain/coupon/controller/CouponWalletController.java
@@ -56,17 +56,19 @@ public class CouponWalletController {
 	@ApiResponses(value = {
 		@ApiResponse(
 			responseCode = "200",
-			description = "쿠폰 사용 현황 조회 성공")
+			description = "쿠폰 사용 현황 조회 성공(쿠폰을 최근에 발급한 사용자를 먼저 보여줍니다.)")
 	})
 	@GetMapping
 	public Mono<ResponseEntity<Page<CouponUsageStatusResponse>>> getCouponUsageStatus(
+		@Parameter(name = "couponId", description = "쿠폰 ID", in = ParameterIn.QUERY)
+		@RequestParam(value = "couponId", required = true) Long couponId,
 		@Parameter(name = "page", description = "페이지네이션의 페이지 넘버. 0부터 시작함", in = ParameterIn.QUERY)
 		@RequestParam(value = "page", required = false, defaultValue = "0") int page,
 		@Parameter(name = "size", description = "페이지네이션의 페이지당 데이터 수", in = ParameterIn.QUERY)
 		@RequestParam(value = "size", required = false, defaultValue = "20") int size
 	) {
 		return Mono.just(PageRequest.of(page, size))
-			.flatMap(couponWalletService::getCouponUsageStatus)
+			.flatMap(pageable -> couponWalletService.getCouponUsageStatus(couponId, pageable))
 			.map(ResponseEntity::ok);
 	}
 

--- a/src/main/java/mujinjang/couponsystem/domain/coupon/dto/response/CouponUsageStatusResponse.java
+++ b/src/main/java/mujinjang/couponsystem/domain/coupon/dto/response/CouponUsageStatusResponse.java
@@ -4,8 +4,7 @@ import java.time.LocalDateTime;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 
-public record CouponUsageStatusResponse(@Schema(description = "쿠폰 id") Long couponId,
-										@Schema(description = "쿠폰 이름") String couponName,
+public record CouponUsageStatusResponse(@Schema(description = "쿠폰 이름") String couponName,
 										@Schema(description = "유저 id") Long userId,
 										@Schema(description = "유저 이름") String username,
 										@Schema(description = "유저가 쿠폰을 발급한 시각") LocalDateTime couponIssuedAt,

--- a/src/main/java/mujinjang/couponsystem/domain/coupon/dto/response/CouponUsageStatusResponse.java
+++ b/src/main/java/mujinjang/couponsystem/domain/coupon/dto/response/CouponUsageStatusResponse.java
@@ -4,8 +4,7 @@ import java.time.LocalDateTime;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 
-public record CouponUsageStatusResponse(@Schema(description = "쿠폰 이름") String couponName,
-										@Schema(description = "유저 id") Long userId,
+public record CouponUsageStatusResponse(@Schema(description = "유저 id") Long userId,
 										@Schema(description = "유저 이름") String username,
 										@Schema(description = "유저가 쿠폰을 발급한 시각") LocalDateTime couponIssuedAt,
 										@Schema(description = "유저가 쿠폰을 사용한 시각", nullable = true)

--- a/src/main/java/mujinjang/couponsystem/domain/coupon/repository/CouponWalletRepository.java
+++ b/src/main/java/mujinjang/couponsystem/domain/coupon/repository/CouponWalletRepository.java
@@ -11,11 +11,9 @@ import reactor.core.publisher.Mono;
 
 public interface CouponWalletRepository extends R2dbcRepository<CouponWallet, Long> {
 
-	@Query("SELECT c.name AS coupon_name, cw.user_id, u.username, cw.created_at "
-		+ "AS coupon_issued_at, cw.used_at AS coupon_used_at "
+	@Query("SELECT cw.user_id, u.username, cw.created_at AS coupon_issued_at, cw.used_at AS coupon_used_at "
 		+ "FROM coupon_wallet cw "
 		+ "INNER JOIN users u ON cw.user_id = u.id "
-		+ "INNER JOIN coupon c ON cw.coupon_id = c.id "
 		+ "WHERE cw.coupon_id = :couponId "
 		+ "ORDER BY cw.created_at DESC "
 		+ "LIMIT :#{#pageable.pageSize} OFFSET :#{#pageable.offset}")

--- a/src/main/java/mujinjang/couponsystem/domain/coupon/repository/CouponWalletRepository.java
+++ b/src/main/java/mujinjang/couponsystem/domain/coupon/repository/CouponWalletRepository.java
@@ -11,14 +11,15 @@ import reactor.core.publisher.Mono;
 
 public interface CouponWalletRepository extends R2dbcRepository<CouponWallet, Long> {
 
-	@Query("SELECT cw.coupon_id, c.name AS coupon_name, cw.user_id, u.username, cw.created_at "
+	@Query("SELECT c.name AS coupon_name, cw.user_id, u.username, cw.created_at "
 		+ "AS coupon_issued_at, cw.used_at AS coupon_used_at "
 		+ "FROM coupon_wallet cw "
 		+ "INNER JOIN users u ON cw.user_id = u.id "
 		+ "INNER JOIN coupon c ON cw.coupon_id = c.id "
+		+ "WHERE cw.coupon_id = :couponId "
 		+ "ORDER BY cw.created_at DESC "
 		+ "LIMIT :#{#pageable.pageSize} OFFSET :#{#pageable.offset}")
-	Flux<CouponUsageStatusResponse> findAllCouponUsageStatus(Pageable pageable);
+	Flux<CouponUsageStatusResponse> findAllCouponUsageStatusByCouponId(Pageable pageable, Long couponId);
 
 	@Query("SELECT * FROM coupon_wallet cw WHERE cw.user_id = :userId AND cw.coupon_id = :couponId")
 	Mono<CouponWallet> findByUserIdAndCouponId(Long userId, Long couponId);

--- a/src/main/java/mujinjang/couponsystem/domain/coupon/service/CouponWalletService.java
+++ b/src/main/java/mujinjang/couponsystem/domain/coupon/service/CouponWalletService.java
@@ -10,7 +10,7 @@ import reactor.core.publisher.Mono;
 public interface CouponWalletService {
 	Mono<IssueCouponWalletResponse> issueCoupon(Long userId, Long couponId);
 
-	Mono<Page<CouponUsageStatusResponse>> getCouponUsageStatus(Pageable pageable);
+	Mono<Page<CouponUsageStatusResponse>> getCouponUsageStatus(Long couponId, Pageable pageable);
 
 	Mono<Void> useCoupon(Long couponWalletId);
 }

--- a/src/main/java/mujinjang/couponsystem/domain/coupon/service/impl/CouponWalletServiceImpl.java
+++ b/src/main/java/mujinjang/couponsystem/domain/coupon/service/impl/CouponWalletServiceImpl.java
@@ -63,8 +63,8 @@ public class CouponWalletServiceImpl implements CouponWalletService {
 	}
 
 	@Override
-	public Mono<Page<CouponUsageStatusResponse>> getCouponUsageStatus(final Pageable pageable) {
-		return couponWalletRepository.findAllCouponUsageStatus(pageable)
+	public Mono<Page<CouponUsageStatusResponse>> getCouponUsageStatus(final Long couponId, final Pageable pageable) {
+		return couponWalletRepository.findAllCouponUsageStatusByCouponId(pageable, couponId)
 			.collectList()
 			.zipWith(couponWalletRepository.count())
 			.map(p -> new PageImpl<>(p.getT1(), pageable, p.getT2()));

--- a/src/test/java/mujinjang/couponsystem/domain/coupon/service/mock/CouponUsageServiceMockTest.java
+++ b/src/test/java/mujinjang/couponsystem/domain/coupon/service/mock/CouponUsageServiceMockTest.java
@@ -52,7 +52,7 @@ public class CouponUsageServiceMockTest {
 	void getCouponUsage_whenCouponWalletExist() {
 		// given
 		CouponUsageStatusResponse couponUsageStatusResponse = new CouponUsageStatusResponse(
-			"couponName", 1L, "username", LocalDateTime.now(), LocalDateTime.now());
+			1L, "username", LocalDateTime.now(), LocalDateTime.now());
 		given(couponWalletRepository.findAllCouponUsageStatusByCouponId(any(Pageable.class), anyLong()))
 			.willReturn(Flux.just(couponUsageStatusResponse));
 		given(couponWalletRepository.count()).willReturn(Mono.just(1L));

--- a/src/test/java/mujinjang/couponsystem/domain/coupon/service/mock/CouponUsageServiceMockTest.java
+++ b/src/test/java/mujinjang/couponsystem/domain/coupon/service/mock/CouponUsageServiceMockTest.java
@@ -1,0 +1,70 @@
+package mujinjang.couponsystem.domain.coupon.service.mock;
+
+import static org.mockito.BDDMockito.*;
+
+import java.time.LocalDateTime;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import mujinjang.couponsystem.domain.coupon.dto.response.CouponUsageStatusResponse;
+import mujinjang.couponsystem.domain.coupon.repository.CouponWalletRepository;
+import mujinjang.couponsystem.domain.coupon.service.impl.CouponWalletServiceImpl;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("getCouponUsageStatus 메서드는")
+public class CouponUsageServiceMockTest {
+
+	@InjectMocks
+	private CouponWalletServiceImpl couponWalletService;
+	@Mock
+	private CouponWalletRepository couponWalletRepository;
+
+	@Test
+	@DisplayName("쿠폰 지갑이 존재하지 않으면 빈 content를 반환한다.")
+	void getCouponUsage_whenCouponWalletNotExist() {
+		// given
+		given(couponWalletRepository.findAllCouponUsageStatusByCouponId(any(Pageable.class), anyLong()))
+			.willReturn(Flux.empty());
+		given(couponWalletRepository.count()).willReturn(Mono.just(0L));
+
+		// when
+		Mono<Page<CouponUsageStatusResponse>> result = couponWalletService.getCouponUsageStatus(1L,
+			Pageable.unpaged());
+
+		// then
+		StepVerifier.create(result)
+			.expectNextMatches(page -> page.getContent().isEmpty())
+			.verifyComplete();
+	}
+
+	@Test
+	@DisplayName("쿠폰 지갑이 존재하면 쿠폰 사용 내역을 반환한다.")
+	void getCouponUsage_whenCouponWalletExist() {
+		// given
+		CouponUsageStatusResponse couponUsageStatusResponse = new CouponUsageStatusResponse(
+			"couponName", 1L, "username", LocalDateTime.now(), LocalDateTime.now());
+		given(couponWalletRepository.findAllCouponUsageStatusByCouponId(any(Pageable.class), anyLong()))
+			.willReturn(Flux.just(couponUsageStatusResponse));
+		given(couponWalletRepository.count()).willReturn(Mono.just(1L));
+
+		// when
+		Mono<Page<CouponUsageStatusResponse>> result = couponWalletService.getCouponUsageStatus(1L,
+			Pageable.unpaged());
+
+		// then
+		StepVerifier.create(result)
+			.expectNextMatches(page -> page.getContent().get(0).equals(couponUsageStatusResponse))
+			.verifyComplete();
+	}
+
+}


### PR DESCRIPTION
### Summary

- couponId에 해당하는 쿠폰의 사용 현황(쿠폰을 발급받은 유저 id, 유저 이름, 유저가 쿠폰을 발급한 시각, 유저가 쿠폰을 사용한 시각)을 반환하도록 수정
- 서비스단 테스트코드 작성

### 고민거리

- controller단 단위테스트를 구현하기 위해 `@WebFluxTest` 애노테이션을 사용했는데 이 경우 main의 `@EnableR2dbcAuditing`가 동작하고, 이에 따른 빈들을 찾다가 실패하여 테스트가 실패합니다. 에러를 해결하기 위해 한 시간 정도 고민했지만 끝내 실패했기에 controller단 단위테스트는 pr에서 제외했습니다.
- repository단 단위테스트는 inmemory h2 db로 돌릴지, testcontainer로 돌릴지 아직 결정하지 않았기에 이번 pr에서 제외했습니다.