### PR TITLE
refactor: 쿠폰 리스트와 단일 쿠폰 조회시 쿠폰 잔여 수량도 함께 반환하도록 수정한다

### DIFF
--- a/src/main/java/mujinjang/couponsystem/domain/coupon/dto/response/CouponInfoResponse.java
+++ b/src/main/java/mujinjang/couponsystem/domain/coupon/dto/response/CouponInfoResponse.java
@@ -14,12 +14,13 @@ public record CouponInfoResponse(@Schema(description = "쿠폰 id") Long couponI
 								 @Schema(description = "쿠폰 코드") String code,
 								 @Schema(description = "쿠폰 종류") String type,
 								 @Schema(description = "할인 정도") Double discount,
-								 @Schema(description = "쿠폰 발급 양", minimum = "1") Long amount,
+								 @Schema(description = "쿠폰 발급 수량", minimum = "1") Long amount,
+								 @Schema(description = "쿠폰 잔여 수량", minimum = "0") Long remainCouponNum,
 								 @Schema(description = "쿠폰 생성일")
 								 @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
 								 LocalDateTime createdAt) {
 
-	public static CouponInfoResponse of(Coupon coupon) {
+	public static CouponInfoResponse of(Coupon coupon, Long remainCouponNum) {
 		return CouponInfoResponse.builder()
 			.couponId(coupon.getId())
 			.name(coupon.getName())
@@ -27,6 +28,7 @@ public record CouponInfoResponse(@Schema(description = "쿠폰 id") Long couponI
 			.type(coupon.getType().name())
 			.discount(coupon.getDiscount())
 			.amount(coupon.getAmount())
+			.remainCouponNum(remainCouponNum)
 			.createdAt(coupon.getCreatedAt())
 			.build();
 	}


### PR DESCRIPTION
### Summary

쿠폰 조회, 쿠폰 리스트 조회시 쿠폰 잔여수량도 함께 반환하도록 수정하는 작업을 진행했습니다.

쿠폰 잔여 수량은 `coupon의 amount(생성할 수 있는 쿠폰 수량) -  redis set에 저장된 userId size(발급한 쿠폰 수량)`으로 결정됩니다.